### PR TITLE
MOTD fix

### DIFF
--- a/src/components/Chat/RenderBubble.js
+++ b/src/components/Chat/RenderBubble.js
@@ -70,6 +70,12 @@ const RenderBubble = (props) => {
           borderColor: "red",
         }
       })
+    } else if (props.currentMessage.user._id === 'system') {
+      updateProps({
+        both: {
+          borderColor: "gray",
+        }
+      })
     } else if (props.currentMessage._id.match(/^sending_/)) {
       updateProps({
         both: {


### PR DESCRIPTION
When setting MOTD, the room crashes -- `props.currentMessage._id.match(/^sending_/)` was failing due to the `_id` property having a value of the number `1`.

Looking back at the file, I noticed a check for the id of the user object, and put it back in (if only temporarily) to fix the issue -- a better structure of the currentMessage blob would be better, so we could have a flag for verified system messages.